### PR TITLE
Fix background color syntax for resize handle hover/active state

### DIFF
--- a/resources/css/resized-column.css
+++ b/resources/css/resized-column.css
@@ -33,7 +33,7 @@
 .column-resize-handle-bar:hover::before,
 .column-resize-handle-bar.active::before {
     width: 2px;
-    background-color: rgb(var(--primary-500));
+    background-color: rgb(from var(--primary-500) r g b);
 }
 
 /* Active resize handle */


### PR DESCRIPTION
Updates the `rgb()` syntax to transform the origin color into the sRGB color space.

For example, Tailwind v4 colors use the `oklch()` color function. This update will define the color in RGB regardless of the color format `--primary-500` is using.