### PR TITLE
Add Livewire feature tests for resize, reorder and sticky columns

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,12 +8,7 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        php: ['8.2', '8.3', '8.4']
-
-    name: PHP ${{ matrix.php }}
+    name: Pest (PHP 8.4)
 
     steps:
       - uses: actions/checkout@v4
@@ -21,12 +16,12 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: ${{ matrix.php }}
+          php-version: '8.4'
           extensions: dom, curl, libxml, mbstring, zip, pdo, sqlite, pdo_sqlite
           coverage: none
 
       - name: Install dependencies
         run: composer update --prefer-dist --no-interaction --no-progress
 
-      - name: Run tests
+      - name: Run Pest tests
         run: vendor/bin/pest

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,8 @@
     "require-dev": {
         "filament/tables": "^4.0",
         "orchestra/testbench": "^9.0|^10.0",
-        "pestphp/pest": "^3.0"
+        "pestphp/pest": "^3.0",
+        "filament/filament": "^4.0"
     },
     "scripts": {
         "test": "pest"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e7dbb279cf6eecb54419370b0a83065d",
+    "content-hash": "2953840ec9f04990bd9ae38ba2edbeee",
     "packages": [
         {
             "name": "blade-ui-kit/blade-heroicons",
@@ -6801,6 +6801,168 @@
             "time": "2026-01-08T08:02:38+00:00"
         },
         {
+            "name": "chillerlan/php-qrcode",
+            "version": "5.0.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/chillerlan/php-qrcode.git",
+                "reference": "7b66282572fc14075c0507d74d9837dab25b38d6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/chillerlan/php-qrcode/zipball/7b66282572fc14075c0507d74d9837dab25b38d6",
+                "reference": "7b66282572fc14075c0507d74d9837dab25b38d6",
+                "shasum": ""
+            },
+            "require": {
+                "chillerlan/php-settings-container": "^2.1.6 || ^3.2.1",
+                "ext-mbstring": "*",
+                "php": "^7.4 || ^8.0"
+            },
+            "require-dev": {
+                "chillerlan/php-authenticator": "^4.3.1 || ^5.2.1",
+                "ext-fileinfo": "*",
+                "phan/phan": "^5.5.2",
+                "phpcompatibility/php-compatibility": "10.x-dev",
+                "phpmd/phpmd": "^2.15",
+                "phpunit/phpunit": "^9.6",
+                "setasign/fpdf": "^1.8.2",
+                "slevomat/coding-standard": "^8.23.0",
+                "squizlabs/php_codesniffer": "^4.0.0"
+            },
+            "suggest": {
+                "chillerlan/php-authenticator": "Yet another Google authenticator! Also creates URIs for mobile apps.",
+                "setasign/fpdf": "Required to use the QR FPDF output.",
+                "simple-icons/simple-icons": "SVG icons that you can use to embed as logos in the QR Code"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "chillerlan\\QRCode\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT",
+                "Apache-2.0"
+            ],
+            "authors": [
+                {
+                    "name": "Kazuhiko Arase",
+                    "homepage": "https://github.com/kazuhikoarase/qrcode-generator"
+                },
+                {
+                    "name": "ZXing Authors",
+                    "homepage": "https://github.com/zxing/zxing"
+                },
+                {
+                    "name": "Ashot Khanamiryan",
+                    "homepage": "https://github.com/khanamiryan/php-qrcode-detector-decoder"
+                },
+                {
+                    "name": "Smiley",
+                    "email": "smiley@chillerlan.net",
+                    "homepage": "https://github.com/codemasher"
+                },
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/chillerlan/php-qrcode/graphs/contributors"
+                }
+            ],
+            "description": "A QR Code generator and reader with a user-friendly API. PHP 7.4+",
+            "homepage": "https://github.com/chillerlan/php-qrcode",
+            "keywords": [
+                "phpqrcode",
+                "qr",
+                "qr code",
+                "qr-reader",
+                "qrcode",
+                "qrcode-generator",
+                "qrcode-reader"
+            ],
+            "support": {
+                "docs": "https://php-qrcode.readthedocs.io",
+                "issues": "https://github.com/chillerlan/php-qrcode/issues",
+                "source": "https://github.com/chillerlan/php-qrcode"
+            },
+            "funding": [
+                {
+                    "url": "https://ko-fi.com/codemasher",
+                    "type": "Ko-Fi"
+                }
+            ],
+            "time": "2025-11-23T23:51:44+00:00"
+        },
+        {
+            "name": "chillerlan/php-settings-container",
+            "version": "3.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/chillerlan/php-settings-container.git",
+                "reference": "a0a487cbf5344f721eb504bf0f59bada40c381b7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/chillerlan/php-settings-container/zipball/a0a487cbf5344f721eb504bf0f59bada40c381b7",
+                "reference": "a0a487cbf5344f721eb504bf0f59bada40c381b7",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "php": "^8.1"
+            },
+            "require-dev": {
+                "phan/phan": "^5.5.2",
+                "phpmd/phpmd": "^2.15",
+                "phpstan/phpstan": "^2.1.31",
+                "phpstan/phpstan-deprecation-rules": "^2.0.3",
+                "phpunit/phpunit": "^10.5",
+                "slevomat/coding-standard": "^8.22",
+                "squizlabs/php_codesniffer": "^4.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "chillerlan\\Settings\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Smiley",
+                    "email": "smiley@chillerlan.net",
+                    "homepage": "https://github.com/codemasher"
+                }
+            ],
+            "description": "A container class for immutable settings objects. Not a DI container.",
+            "homepage": "https://github.com/chillerlan/php-settings-container",
+            "keywords": [
+                "Settings",
+                "configuration",
+                "container",
+                "helper",
+                "property hook"
+            ],
+            "support": {
+                "issues": "https://github.com/chillerlan/php-settings-container/issues",
+                "source": "https://github.com/chillerlan/php-settings-container"
+            },
+            "funding": [
+                {
+                    "url": "https://www.paypal.com/donate?hosted_button_id=WLYUNAT9ZTJZ4",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://ko-fi.com/codemasher",
+                    "type": "ko_fi"
+                }
+            ],
+            "time": "2026-03-20T21:10:52+00:00"
+        },
+        {
             "name": "composer/semver",
             "version": "3.4.4",
             "source": {
@@ -7150,6 +7312,63 @@
             "time": "2026-07-02T08:12:40+00:00"
         },
         {
+            "name": "filament/filament",
+            "version": "v4.11.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/filamentphp/panels.git",
+                "reference": "b682c419917750326d61c28dc6b1ceb6d5d7da9a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/filamentphp/panels/zipball/b682c419917750326d61c28dc6b1ceb6d5d7da9a",
+                "reference": "b682c419917750326d61c28dc6b1ceb6d5d7da9a",
+                "shasum": ""
+            },
+            "require": {
+                "chillerlan/php-qrcode": "^5.0",
+                "filament/actions": "self.version",
+                "filament/forms": "self.version",
+                "filament/infolists": "self.version",
+                "filament/notifications": "self.version",
+                "filament/schemas": "self.version",
+                "filament/support": "self.version",
+                "filament/tables": "self.version",
+                "filament/widgets": "self.version",
+                "php": "^8.2",
+                "pragmarx/google2fa": "^8.0|^9.0",
+                "pragmarx/google2fa-qrcode": "^3.0|^4.0"
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "providers": [
+                        "Filament\\FilamentServiceProvider"
+                    ]
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/global_helpers.php",
+                    "src/helpers.php"
+                ],
+                "psr-4": {
+                    "Filament\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "A collection of full-stack components for accelerated Laravel app development.",
+            "homepage": "https://github.com/filamentphp/filament",
+            "support": {
+                "issues": "https://github.com/filamentphp/filament/issues",
+                "source": "https://github.com/filamentphp/filament"
+            },
+            "time": "2026-07-02T08:09:52+00:00"
+        },
+        {
             "name": "filament/forms",
             "version": "v4.11.8",
             "source": {
@@ -7427,6 +7646,50 @@
                 "source": "https://github.com/filamentphp/filament"
             },
             "time": "2026-07-02T08:16:33+00:00"
+        },
+        {
+            "name": "filament/widgets",
+            "version": "v4.11.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/filamentphp/widgets.git",
+                "reference": "a7a88af16c01817ba6c7802f4f0bcf66b9101201"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/filamentphp/widgets/zipball/a7a88af16c01817ba6c7802f4f0bcf66b9101201",
+                "reference": "a7a88af16c01817ba6c7802f4f0bcf66b9101201",
+                "shasum": ""
+            },
+            "require": {
+                "filament/schemas": "self.version",
+                "filament/support": "self.version",
+                "php": "^8.2"
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "providers": [
+                        "Filament\\Widgets\\WidgetsServiceProvider"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Filament\\Widgets\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Easily add beautiful dashboard widgets to any Livewire component.",
+            "homepage": "https://github.com/filamentphp/filament",
+            "support": {
+                "issues": "https://github.com/filamentphp/filament/issues",
+                "source": "https://github.com/filamentphp/filament"
+            },
+            "time": "2026-07-02T08:19:13+00:00"
         },
         {
             "name": "filp/whoops",
@@ -8656,6 +8919,75 @@
             "time": "2026-03-24T23:02:25+00:00"
         },
         {
+            "name": "paragonie/constant_time_encoding",
+            "version": "v3.1.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/paragonie/constant_time_encoding.git",
+                "reference": "d5b01a39b3415c2cd581d3bd3a3575c1ebbd8e77"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/paragonie/constant_time_encoding/zipball/d5b01a39b3415c2cd581d3bd3a3575c1ebbd8e77",
+                "reference": "d5b01a39b3415c2cd581d3bd3a3575c1ebbd8e77",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^8"
+            },
+            "require-dev": {
+                "infection/infection": "^0",
+                "nikic/php-fuzzer": "^0",
+                "phpunit/phpunit": "^9|^10|^11",
+                "vimeo/psalm": "^4|^5|^6"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "ParagonIE\\ConstantTime\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Paragon Initiative Enterprises",
+                    "email": "security@paragonie.com",
+                    "homepage": "https://paragonie.com",
+                    "role": "Maintainer"
+                },
+                {
+                    "name": "Steve 'Sc00bz' Thomas",
+                    "email": "steve@tobtu.com",
+                    "homepage": "https://www.tobtu.com",
+                    "role": "Original Developer"
+                }
+            ],
+            "description": "Constant-time Implementations of RFC 4648 Encoding (Base-64, Base-32, Base-16)",
+            "keywords": [
+                "base16",
+                "base32",
+                "base32_decode",
+                "base32_encode",
+                "base64",
+                "base64_decode",
+                "base64_encode",
+                "bin2hex",
+                "encoding",
+                "hex",
+                "hex2bin",
+                "rfc4648"
+            ],
+            "support": {
+                "email": "info@paragonie.com",
+                "issues": "https://github.com/paragonie/constant_time_encoding/issues",
+                "source": "https://github.com/paragonie/constant_time_encoding"
+            },
+            "time": "2025-09-24T15:06:41+00:00"
+        },
+        {
             "name": "pestphp/pest",
             "version": "v3.8.7",
             "source": {
@@ -9760,6 +10092,126 @@
                 }
             ],
             "time": "2026-07-06T14:52:39+00:00"
+        },
+        {
+            "name": "pragmarx/google2fa",
+            "version": "v9.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/antonioribeiro/google2fa.git",
+                "reference": "e6bc62dd6ae83acc475f57912e27466019a1f2cf"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/antonioribeiro/google2fa/zipball/e6bc62dd6ae83acc475f57912e27466019a1f2cf",
+                "reference": "e6bc62dd6ae83acc475f57912e27466019a1f2cf",
+                "shasum": ""
+            },
+            "require": {
+                "paragonie/constant_time_encoding": "^1.0|^2.0|^3.0",
+                "php": "^7.1|^8.0"
+            },
+            "require-dev": {
+                "phpstan/phpstan": "^1.9",
+                "phpunit/phpunit": "^7.5.15|^8.5|^9.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "PragmaRX\\Google2FA\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Antonio Carlos Ribeiro",
+                    "email": "acr@antoniocarlosribeiro.com",
+                    "role": "Creator & Designer"
+                }
+            ],
+            "description": "A One Time Password Authentication package, compatible with Google Authenticator.",
+            "keywords": [
+                "2fa",
+                "Authentication",
+                "Two Factor Authentication",
+                "google2fa"
+            ],
+            "support": {
+                "issues": "https://github.com/antonioribeiro/google2fa/issues",
+                "source": "https://github.com/antonioribeiro/google2fa/tree/v9.0.0"
+            },
+            "time": "2025-09-19T22:51:08+00:00"
+        },
+        {
+            "name": "pragmarx/google2fa-qrcode",
+            "version": "v4.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/antonioribeiro/google2fa-qrcode.git",
+                "reference": "16159f84fa0838c276f35d46de57fd90dfbb385c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/antonioribeiro/google2fa-qrcode/zipball/16159f84fa0838c276f35d46de57fd90dfbb385c",
+                "reference": "16159f84fa0838c276f35d46de57fd90dfbb385c",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^8.1",
+                "pragmarx/google2fa": "^8.0|^9.0"
+            },
+            "require-dev": {
+                "bacon/bacon-qr-code": "^2.0|^3.0",
+                "chillerlan/php-qrcode": "^5.0|^6.0",
+                "khanamiryan/qrcode-detector-decoder": "^1.0",
+                "phpstan/phpstan": "^2.0",
+                "phpunit/phpunit": "~9|~10|~11|~12|~13"
+            },
+            "suggest": {
+                "bacon/bacon-qr-code": "For QR Code generation, requires imagick",
+                "chillerlan/php-qrcode": "For QR Code generation"
+            },
+            "type": "library",
+            "extra": {
+                "component": "package",
+                "branch-alias": {
+                    "dev-master": "1.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "PragmaRX\\Google2FAQRCode\\": "src/",
+                    "PragmaRX\\Google2FAQRCode\\Tests\\": "tests/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Antonio Carlos Ribeiro",
+                    "email": "acr@antoniocarlosribeiro.com",
+                    "role": "Creator & Designer"
+                }
+            ],
+            "description": "QR Code package for Google2FA",
+            "keywords": [
+                "2fa",
+                "Authentication",
+                "Two Factor Authentication",
+                "google2fa",
+                "qr code",
+                "qrcode"
+            ],
+            "support": {
+                "issues": "https://github.com/antonioribeiro/google2fa-qrcode/issues",
+                "source": "https://github.com/antonioribeiro/google2fa-qrcode/tree/v4.0.0"
+            },
+            "time": "2026-05-08T19:24:44+00:00"
         },
         {
             "name": "psy/psysh",

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -10,6 +10,10 @@
             <directory>tests</directory>
         </testsuite>
     </testsuites>
+    <php>
+        <env name="APP_KEY" value="base64:AckfSECXIvnK5r28GVIWUAxmbBSjTsmF/0rZh1EFA0k="/>
+        <env name="DB_CONNECTION" value="testing"/>
+    </php>
     <source>
         <include>
             <directory>src</directory>

--- a/src/Setup/Setup.php
+++ b/src/Setup/Setup.php
@@ -15,7 +15,7 @@ class Setup
                 return false;
             }
             return filament()->hasPlugin('asmit-resized-column') && filament()->getDefaultPanel();
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) { // filament() is undefined without filament/panels
             return false;
         }
     }

--- a/tests/Feature/ResizableColumnLivewireTest.php
+++ b/tests/Feature/ResizableColumnLivewireTest.php
@@ -1,0 +1,162 @@
+<?php
+
+use Asmit\ResizedColumn\Models\TableSetting;
+use Asmit\ResizedColumn\ResizedColumnTableRegistry;
+use Asmit\ResizedColumn\Tests\Fixtures\DatabaseTable;
+use Asmit\ResizedColumn\Tests\Fixtures\PlainTable;
+use Illuminate\Foundation\Auth\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Livewire\Livewire;
+
+uses(RefreshDatabase::class);
+
+beforeEach(function () {
+    ResizedColumnTableRegistry::reset();
+    session()->flush();
+
+    // Settings rows are keyed by Auth::id(), so DB persistence needs a user.
+    $this->actingAs((new User)->forceFill(['id' => 7]));
+});
+
+it('applies the resized width to the header and cell attributes on the next render', function () {
+    // updateColumnWidth() is #[Renderless] — the browser already resized the
+    // column, so the width only reaches the markup on the following request.
+    Livewire::test(PlainTable::class)
+        ->call('updateColumnWidth', 'alpha', '240');
+
+    $alpha = columnsOf(Livewire::test(PlainTable::class)->instance())['alpha'];
+
+    expect($alpha->getExtraHeaderAttributes()['style'])
+        ->toBe('min-width: 240px; width: 240px; max-width: 240px')
+        ->and($alpha->getExtraCellAttributes()['style'])
+        ->toBe('min-width: 240px; width: 240px; max-width: 240px; overflow: hidden');
+});
+
+it('persists a resized width to the session', function () {
+    Livewire::test(PlainTable::class)
+        ->call('updateColumnWidth', 'alpha', '240');
+
+    expect(session('tables.plain_table_columns_style'))
+        ->toBe(['alpha' => ['width' => '240']]);
+});
+
+it('rehydrates widths from the session on mount', function () {
+    session()->put('tables.plain_table_columns_style', ['beta' => ['width' => '180']]);
+
+    $component = Livewire::test(PlainTable::class);
+
+    expect(columnsOf($component->instance())['beta']->getExtraHeaderAttributes()['style'])
+        ->toBe('min-width: 180px; width: 180px; max-width: 180px');
+});
+
+it('tags every header with the column name and html id', function () {
+    $component = Livewire::test(PlainTable::class);
+
+    $attributes = columnsOf($component->instance())['alpha']->getExtraHeaderAttributes();
+
+    expect($attributes['data-column-name'])->toBe('alpha')
+        ->and($attributes['data-column-id'])->toBe('alpha')
+        ->and($attributes['class'])->toContain('group/column-resize');
+});
+
+it('does not mark headers reorderable unless dragReorderableColumns is enabled', function () {
+    $component = Livewire::test(PlainTable::class);
+
+    $attributes = columnsOf($component->instance())['alpha']->getExtraHeaderAttributes();
+
+    expect($attributes)->not->toHaveKey('data-resized-reorderable')
+        ->and($attributes)->not->toHaveKey('data-stickable');
+});
+
+it('reorders columns and persists the order for the next request', function () {
+    $component = Livewire::test(DatabaseTable::class)
+        ->call('updateColumnOrder', ['gamma', 'alpha', 'beta']);
+
+    expect(array_keys(columnsOf($component->instance())))
+        ->toBe(['gamma', 'alpha', 'beta']);
+
+    // A fresh mount rebuilds the table, then reapplies the saved order.
+    expect(array_keys(columnsOf(Livewire::test(DatabaseTable::class)->instance())))
+        ->toBe(['gamma', 'alpha', 'beta']);
+});
+
+it('appends unknown and missing columns after the saved order', function () {
+    $component = Livewire::test(PlainTable::class)
+        ->call('updateColumnOrder', ['gamma', 'unknown-column']);
+
+    expect(array_keys(columnsOf($component->instance())))
+        ->toBe(['gamma', 'alpha', 'beta']);
+});
+
+it('ignores non-string entries in a submitted column order', function () {
+    $component = Livewire::test(PlainTable::class)
+        ->call('updateColumnOrder', ['gamma', 42, null, 'alpha']);
+
+    expect(array_keys(columnsOf($component->instance())))
+        ->toBe(['gamma', 'alpha', 'beta']);
+});
+
+it('writes widths and order to the database when the table opts in', function () {
+    Livewire::test(DatabaseTable::class)
+        ->call('updateColumnWidth', 'alpha', '300')
+        ->call('updateColumnOrder', ['beta', 'alpha', 'gamma']);
+
+    $setting = TableSetting::query()
+        ->where('resource', DatabaseTable::class)
+        ->sole();
+
+    expect($setting->styles)->toBe([
+        'alpha' => ['width' => '300'],
+        '__order' => ['beta', 'alpha', 'gamma'],
+    ]);
+});
+
+it('keeps widths out of the database for a session-only table', function () {
+    Livewire::test(PlainTable::class)
+        ->call('updateColumnWidth', 'alpha', '300');
+
+    expect(TableSetting::count())->toBe(0);
+});
+
+it('loads persisted widths from the database when the session is empty', function () {
+    TableSetting::create([
+        'user_id' => 7,
+        'resource' => DatabaseTable::class,
+        'styles' => [
+            'gamma' => ['width' => '420'],
+            '__order' => ['gamma', 'beta', 'alpha'],
+        ],
+    ]);
+
+    $component = Livewire::test(DatabaseTable::class);
+
+    expect(array_keys(columnsOf($component->instance())))->toBe(['gamma', 'beta', 'alpha'])
+        ->and(columnsOf($component->instance())['gamma']->getExtraHeaderAttributes()['style'])
+        ->toBe('min-width: 420px; width: 420px; max-width: 420px');
+
+    // The database read is mirrored into the session so later requests skip it.
+    expect(session('tables.database_table_columns_style'))
+        ->toBe(['gamma' => ['width' => '420'], '__order' => ['gamma', 'beta', 'alpha']]);
+});
+
+it('scopes database rows per user', function () {
+    TableSetting::create([
+        'user_id' => 99,
+        'resource' => DatabaseTable::class,
+        'styles' => ['gamma' => ['width' => '420']],
+    ]);
+
+    $component = Livewire::test(DatabaseTable::class);
+
+    expect(columnsOf($component->instance())['gamma']->getExtraHeaderAttributes())
+        ->not->toHaveKey('style');
+});
+
+it('marks headers as reorderable when dragReorderableColumns is enabled', function () {
+    $component = Livewire::test(DatabaseTable::class);
+
+    $attributes = columnsOf($component->instance())['alpha']->getExtraHeaderAttributes();
+
+    expect($attributes['data-resized-reorderable'])->toBe('true')
+        ->and($attributes['class'])->toContain('resized-reorderable-col');
+});

--- a/tests/Feature/StickyColumnLivewireTest.php
+++ b/tests/Feature/StickyColumnLivewireTest.php
@@ -1,0 +1,103 @@
+<?php
+
+use Asmit\ResizedColumn\ResizedColumnTableRegistry;
+use Asmit\ResizedColumn\Tests\Fixtures\PlainTable;
+use Asmit\ResizedColumn\Tests\Fixtures\StickyTable;
+use Illuminate\Foundation\Auth\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Livewire\Livewire;
+
+uses(RefreshDatabase::class);
+
+beforeEach(function () {
+    ResizedColumnTableRegistry::reset();
+    session()->flush();
+
+    $this->actingAs((new User)->forceFill(['id' => 7]));
+});
+
+it('pins dev-declared sticky columns and moves them to the front', function () {
+    $component = Livewire::test(StickyTable::class);
+
+    expect(array_keys(columnsOf($component->instance())))->toBe(['beta', 'alpha', 'gamma']);
+
+    $beta = columnsOf($component->instance())['beta'];
+
+    expect($beta->getExtraHeaderAttributes()['data-sticky'])->toBe('left')
+        ->and($beta->getExtraHeaderAttributes()['data-sticky-locked'])->toBe('true')
+        ->and($beta->getExtraHeaderAttributes()['class'])->toContain('resized-sticky')
+        ->and($beta->getExtraCellAttributes()['data-sticky'])->toBe('left');
+});
+
+it('marks headers stickable when the table opts into stickableColumns', function () {
+    $component = Livewire::test(StickyTable::class);
+
+    expect(columnsOf($component->instance())['alpha']->getExtraHeaderAttributes()['data-stickable'])
+        ->toBe('true');
+});
+
+it('pins a column at runtime and persists the selection', function () {
+    $component = Livewire::test(StickyTable::class)
+        ->call('toggleColumnSticky', 'gamma');
+
+    expect(array_keys(columnsOf($component->instance())))->toBe(['beta', 'gamma', 'alpha'])
+        ->and(columnsOf($component->instance())['gamma']->getExtraHeaderAttributes()['data-sticky'])
+        ->toBe('left');
+
+    expect(session('tables.sticky_table_columns_style')['__sticky'])
+        ->toBe(['beta', 'gamma']);
+});
+
+it('unpins a user-pinned column', function () {
+    $component = Livewire::test(StickyTable::class)
+        ->call('toggleColumnSticky', 'gamma')
+        ->call('toggleColumnSticky', 'gamma');
+
+    expect(session('tables.sticky_table_columns_style')['__sticky'])->toBe(['beta'])
+        ->and(columnsOf($component->instance())['gamma']->getExtraHeaderAttributes())
+        ->not->toHaveKey('data-sticky');
+});
+
+it('refuses to unpin a dev-declared sticky column', function () {
+    Livewire::test(StickyTable::class)
+        ->call('toggleColumnSticky', 'beta');
+
+    expect(array_keys(columnsOf(Livewire::test(StickyTable::class)->instance())))
+        ->toBe(['beta', 'alpha', 'gamma']);
+});
+
+it('ignores sticky toggles on a table that is not stickable', function () {
+    $component = Livewire::test(PlainTable::class)
+        ->call('toggleColumnSticky', 'alpha');
+
+    expect(columnsOf($component->instance())['alpha']->getExtraHeaderAttributes())
+        ->not->toHaveKey('data-sticky')
+        ->and(session('tables.plain_table_columns_style'))->toBeNull();
+});
+
+it('replaces the whole selection with setStickyColumns', function () {
+    $component = Livewire::test(StickyTable::class)
+        ->call('setStickyColumns', ['gamma', 'alpha']);
+
+    // Dev-declared sticky columns are merged back in and lead the order.
+    expect(session('tables.sticky_table_columns_style')['__sticky'])
+        ->toBe(['beta', 'gamma', 'alpha'])
+        ->and(array_keys(columnsOf($component->instance())))
+        ->toBe(['beta', 'gamma', 'alpha']);
+});
+
+it('drops unknown column names passed to setStickyColumns', function () {
+    Livewire::test(StickyTable::class)
+        ->call('setStickyColumns', ['gamma', 'nope', 42]);
+
+    expect(session('tables.sticky_table_columns_style')['__sticky'])
+        ->toBe(['beta', 'gamma']);
+});
+
+it('restores a persisted sticky selection on the next mount', function () {
+    session()->put('tables.sticky_table_columns_style', ['__sticky' => ['gamma']]);
+
+    $component = Livewire::test(StickyTable::class);
+
+    expect(array_keys(columnsOf($component->instance())))->toBe(['beta', 'gamma', 'alpha']);
+});

--- a/tests/Fixtures/DatabaseTable.php
+++ b/tests/Fixtures/DatabaseTable.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Asmit\ResizedColumn\Tests\Fixtures;
+
+use Filament\Tables\Table;
+
+/**
+ * Opts into database persistence via the ->preserveColumnWidthsInDatabase() macro.
+ */
+class DatabaseTable extends PlainTable
+{
+    public function table(Table $table): Table
+    {
+        return parent::table($table)
+            ->dragReorderableColumns()
+            ->preserveColumnWidthsInDatabase();
+    }
+}

--- a/tests/Fixtures/PlainTable.php
+++ b/tests/Fixtures/PlainTable.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Asmit\ResizedColumn\Tests\Fixtures;
+
+use Asmit\ResizedColumn\HasResizableColumn;
+use Filament\Actions\Concerns\InteractsWithActions;
+use Filament\Actions\Contracts\HasActions;
+use Filament\Schemas\Concerns\InteractsWithSchemas;
+use Filament\Schemas\Contracts\HasSchemas;
+use Filament\Support\Contracts\TranslatableContentDriver;
+use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Concerns\InteractsWithTable;
+use Filament\Tables\Contracts\HasTable;
+use Filament\Tables\Table;
+use Livewire\Component;
+
+/**
+ * Default configuration: session persistence, no reorder, no sticky.
+ *
+ * HasResizableColumn is declared last, as the README prescribes: its booted
+ * hook reads getTable(), so InteractsWithTable must boot first.
+ */
+class PlainTable extends Component implements HasActions, HasSchemas, HasTable
+{
+    use InteractsWithActions;
+    use InteractsWithSchemas;
+    use InteractsWithTable;
+    use HasResizableColumn;
+
+    public function makeFilamentTranslatableContentDriver(): ?TranslatableContentDriver
+    {
+        return null;
+    }
+
+    public function table(Table $table): Table
+    {
+        return $table
+            ->columns([
+                TextColumn::make('alpha'),
+                TextColumn::make('beta'),
+                TextColumn::make('gamma'),
+            ]);
+    }
+
+    public function render(): string
+    {
+        return '<div></div>';
+    }
+}

--- a/tests/Fixtures/StickyTable.php
+++ b/tests/Fixtures/StickyTable.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Asmit\ResizedColumn\Tests\Fixtures;
+
+use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Table;
+
+/**
+ * User-controlled pinning (->stickableColumns()) with one dev-declared
+ * sticky column (beta) that users may not unpin.
+ */
+class StickyTable extends PlainTable
+{
+    public function table(Table $table): Table
+    {
+        return $table
+            ->columns([
+                TextColumn::make('alpha'),
+                TextColumn::make('beta')->sticky(),
+                TextColumn::make('gamma'),
+            ])
+            ->stickableColumns();
+    }
+}

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -1,3 +1,11 @@
 <?php
 
 uses(Asmit\ResizedColumn\Tests\TestCase::class)->in(__DIR__);
+
+/**
+ * @return array<string, \Filament\Tables\Columns\Column>
+ */
+function columnsOf(object $component): array
+{
+    return $component->getTable()->getColumns();
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -3,19 +3,42 @@
 namespace Asmit\ResizedColumn\Tests;
 
 use Asmit\ResizedColumn\ResizedColumnServiceProvider;
+use BladeUI\Heroicons\BladeHeroiconsServiceProvider;
+use BladeUI\Icons\BladeIconsServiceProvider;
+use Filament\Actions\ActionsServiceProvider;
+use Filament\FilamentServiceProvider;
+use Filament\Forms\FormsServiceProvider;
+use Filament\Infolists\InfolistsServiceProvider;
+use Filament\Notifications\NotificationsServiceProvider;
+use Filament\Schemas\SchemasServiceProvider;
 use Filament\Support\SupportServiceProvider;
 use Filament\Tables\TablesServiceProvider;
+use Filament\Widgets\WidgetsServiceProvider;
 use Livewire\LivewireServiceProvider;
 use Orchestra\Testbench\TestCase as Orchestra;
+use RyanChandler\BladeCaptureDirective\BladeCaptureDirectiveServiceProvider;
 
 class TestCase extends Orchestra
 {
     protected function getPackageProviders($app): array
     {
         return [
-            LivewireServiceProvider::class,
+            BladeCaptureDirectiveServiceProvider::class,
+            BladeIconsServiceProvider::class,
+            BladeHeroiconsServiceProvider::class,
             SupportServiceProvider::class,
+            ActionsServiceProvider::class,
+            SchemasServiceProvider::class,
+            FormsServiceProvider::class,
+            InfolistsServiceProvider::class,
+            NotificationsServiceProvider::class,
+            WidgetsServiceProvider::class,
             TablesServiceProvider::class,
+            FilamentServiceProvider::class,
+            // After Filament: SupportServiceProvider rebinds Livewire's
+            // DataStore, which drops the singleton instance if it registers
+            // afterwards.
+            LivewireServiceProvider::class,
             ResizedColumnServiceProvider::class,
         ];
     }


### PR DESCRIPTION
## What

23 Livewire feature tests driving the package's public API through real `Livewire::test()` mounts, plus the test-harness plumbing they need.

**`tests/Feature/ResizableColumnLivewireTest.php`**
- `updateColumnWidth()` — session persistence, DB persistence via `->preserveColumnWidthsInDatabase()`, applied header/cell styles on the next render (the action is `#[Renderless]`), no DB write for session-only tables
- `updateColumnOrder()` — reorder applies immediately and survives a fresh mount, unknown/non-string entries are dropped, remaining columns appended
- Blob hydration — DB read mirrored into the session, rows scoped per `Auth::id()`
- Header markers: `data-column-name`, `data-column-id`, `data-resized-reorderable`

**`tests/Feature/StickyColumnLivewireTest.php`**
- `->sticky()` defaults pin and move to the front, emitting `data-sticky` / `data-sticky-locked`
- `toggleColumnSticky()` pin/unpin round trip, refusal to unpin a dev-declared sticky column, no-op when the table is not `->stickableColumns()`
- `setStickyColumns()` replaces the selection, merges dev sticky columns back in, drops unknown names
- Persisted `__sticky` selection restored on the next mount

**Fixtures** — `PlainTable` (defaults), `DatabaseTable` (DB + reorder macros), `StickyTable` (`->sticky()` + `->stickableColumns()`).

## Supporting changes

- `composer.json` — `filament/filament` added as a dev dependency. The standalone config path resolves `ResizedColumnPlugin`, which implements `Filament\Contracts\Plugin`, so the panel package must be present to boot a component under test.
- `tests/TestCase.php` — registers the Filament provider chain. `LivewireServiceProvider` must come **after** `Filament\Support\SupportServiceProvider`: Support rebinds Livewire's `DataStore` with `bind()`, which drops the singleton instance if Livewire registers first, and error-bag state is then lost mid-render.
- `phpunit.xml` — `APP_KEY` and `DB_CONNECTION=testing`.
- `src/Setup/Setup.php` — `resizedColumnPlugged()` caught `\Exception`, but a missing `filament()` helper (no `filament/panels` installed, which the composer constraints allow) throws `Error`. Widened to `\Throwable`.

## Not included

Pest browser tests. They need a Pest 3 → 4 upgrade plus `pest-plugin-browser` and a Playwright install, and a served route rendering a real Filament table — a separate change from this suite. The drag-resize, drag-reorder and pin-panel interactions live in `resources/js`, so they remain uncovered; the Livewire tests here cover the server side those scripts talk to.

## Verification

`vendor/bin/pest` — 39 passed (71 assertions).