### PR TITLE
chore: harden supply chain and add security policy

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,5 @@
 /.gitattributes export-ignore
+/composer.lock export-ignore
 /package.json export-ignore
 /package-lock.json export-ignore
 /.gitignore export-ignore

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,22 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    cooldown:
+      default-days: 7
+
+  - package-ecosystem: composer
+    directory: /
+    schedule:
+      interval: weekly
+    cooldown:
+      default-days: 7
+
+  - package-ecosystem: npm
+    directory: /docs
+    schedule:
+      interval: weekly
+    cooldown:
+      default-days: 7

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -22,18 +22,18 @@ jobs:
       run:
         working-directory: docs
     steps:
-      - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.3.0
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.2.0
         with:
           version: 11
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 22
           cache: pnpm
           cache-dependency-path: docs/pnpm-lock.yaml
       - run: pnpm install --frozen-lockfile
       - run: pnpm generate
-      - uses: actions/upload-pages-artifact@v3
+      - uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3.0.1
         with:
           path: docs/.output/public
 
@@ -45,4 +45,4 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4.0.5

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,10 +11,10 @@ jobs:
     name: Pest (PHP 8.4)
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.3.0
 
       - name: Setup PHP
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # v2
         with:
           php-version: '8.4'
           extensions: dom, curl, libxml, mbstring, zip, pdo, sqlite, pdo_sqlite

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,21 @@
+# Security Policy
+
+## Supported Versions
+
+| Version | Supported |
+| ------- | --------- |
+| 4.x     | Yes       |
+| 3.x     | Yes       |
+| < 3.0   | No        |
+
+## Reporting a Vulnerability
+
+Do not open a public issue for security problems.
+
+Report privately via [GitHub Security Advisories](https://github.com/AsmitNepali/resized-column/security/advisories/new),
+or email mail2asmitnepali@gmail.com.
+
+Include: affected version, reproduction steps, and impact.
+
+You will get an acknowledgement within 7 days. Confirmed issues are fixed in a
+patch release, and the report is credited in the advisory unless you ask otherwise.


### PR DESCRIPTION
Addresses the failing checks on the Plumb health report shown on the Filament plugin page (score was 70).

## Changes

**Pin GitHub Actions to commit SHAs** (`.github/workflows/{tests,docs}.yml`)

All 6 `uses:` refs moved from mutable tags to commit SHAs, with the version kept as a trailing comment for readability and Dependabot. Tags can be re-pointed by the action owner at any time — the `tj-actions/changed-files` compromise worked exactly that way. SHAs are content-addressed and can't be rewritten.

**Add Dependabot config** (`.github/dependabot.yml`)

Three ecosystems, matching the three dependency trees: `github-actions` (/), `composer` (/), `npm` (/docs). Weekly, not daily — this is a library. This pairs with the SHA pinning: pinning without an updater just trades a mutable ref for a permanently stale one.

**Dependency update cooldown**

`cooldown: default-days: 7` per ecosystem. Bad or malicious releases are usually yanked within days; a release has to age a week before Dependabot proposes it.

**Add `SECURITY.md`**

Supported-versions table, private reporting via GitHub Security Advisories with email fallback, and a 7-day acknowledgement commitment. Without this the only reporting channel is a public issue — full disclosure with no patch window.

**Stop shipping `composer.lock`** (`.gitattributes`)

A library's lock file is ignored by Composer when resolving for a consuming project, so it's dead weight in the dist archive. Still committed for CI, just `export-ignore`d from the tarball.

## Verification

`composer.lock` removal confirmed against the actual archive rather than assumed:

```
$ git archive HEAD | tar -t | grep -c composer.lock
1
$ git archive --worktree-attributes HEAD | tar -t | grep composer.lock
composer.lock excluded
```

CI on this PR exercises the pinned `actions/checkout` and `shivammathur/setup-php` refs directly — a bad SHA fails the job.

## Follow-ups (not in this PR)

- Private vulnerability reporting must be enabled in **Settings → Code security**, or the advisory link in `SECURITY.md` 404s for reporters.
- The dist-archive check won't re-evaluate until a **new release** is cut — the existing `4.0.0-beta.3` tarball still contains the lock file.