### PR TITLE
test: fix stale registry defaults assertion breaking CI

### DIFF
--- a/tests/Unit/ResizedColumnTableRegistryTest.php
+++ b/tests/Unit/ResizedColumnTableRegistryTest.php
@@ -17,8 +17,9 @@ it('applies documented defaults on first register', function () {
 
     expect(ResizedColumnTableRegistry::has('App\\Foo'))->toBeTrue();
     expect(ResizedColumnTableRegistry::isStickable('App\\Foo'))->toBeTrue();
-    expect(ResizedColumnTableRegistry::shouldPreserveOnDb('App\\Foo'))->toBeFalse();
-    expect(ResizedColumnTableRegistry::shouldPreserveOnSession('App\\Foo'))->toBeTrue();
+    // null = unset, so panel-level preserveOnDB()/preserveOnSession() still apply
+    expect(ResizedColumnTableRegistry::shouldPreserveOnDb('App\\Foo'))->toBeNull();
+    expect(ResizedColumnTableRegistry::shouldPreserveOnSession('App\\Foo'))->toBeNull();
     expect(ResizedColumnTableRegistry::isReorderable('App\\Foo'))->toBeFalse();
 });
 


### PR DESCRIPTION
## Problem

CI failed on:

```
Tests\Unit\ResizedColumnTableRegistryTest > it applies documented…
Failed asserting that null is false.
```

## Cause

`f8b33d6` (fix(persistence): inherit global preserveOnDB for stickable tables) changed `ResizedColumnTableRegistry::register()` defaults for `preserveOnDb` / `preserveOnSession` from `false` / `true` to `null`.

That was deliberate. `null` is a third state meaning "this table set no per-table opinion", which lets `LoadResizedColumn::isPreservedOnDB()` distinguish an explicit `->preserveColumnWidthsInDatabase(false)` opt-out from a table that merely called `stickableColumns()` and never mentioned persistence. Previously any registered table stored `preserveOnDb => false` and silently shadowed a panel-level `preserveOnDB()`, leaving sticky columns session-only across logout.

That commit updated `LoadResizedColumn` and `tests/Feature/StickyColumnLivewireTest.php`, but not this unit test, which still asserted the old two-state defaults. The sibling test in the same file already asserts `toBeNull()` for the unregistered case, so the two contradicted each other.

## Change

Assert `toBeNull()` for both flags after `register('App\Foo', stickable: true)`, matching the current contract. Test-only; no source change — the code is correct.

## Verification

`vendor/bin/pest` — 42 passed, 79 assertions.

## Follow-up (not done here)

The test name "applies documented defaults on first register" is now stale — the registry no longer decides defaults, `Setup::preserveOnSession()` / `Setup::preserveOnDB()` do. Worth renaming to something like "leaves persistence flags unset when only stickable is registered".