### PR TITLE
fix: keep toolbar modals above Filament chrome

### DIFF
--- a/resources/css/resized-column.css
+++ b/resources/css/resized-column.css
@@ -159,6 +159,18 @@ thead th.fi-ta-header-cell.resized-column-is-resizing {
     z-index: 21;
 }
 
+/*
+ * That stacking context also traps toolbar *modals*. A column manager or filter
+ * trigger configured with ->modal()/->slideOver() renders its overlay inside
+ * .fi-ta-header-ctn, so the overlay's own z-index (40) resolves within this
+ * context and the whole modal still paints under the topbar (z-index 30).
+ * While such a modal is open, lift the context above Filament chrome; the
+ * overlay covers the page anyway, so nothing else needs to stay on top.
+ */
+.fi-ta-ctn .fi-ta-header-ctn:has(.fi-modal.fi-modal-open) {
+    z-index: 50;
+}
+
 /* Opaque header cells so scrolled rows cannot show through the thead.
    Prefer inherit so host themes (e.g. Primo #EAEEF2) keep their surface. */
 .sticky-table .fi-ta-table>thead>tr>th.fi-ta-header-cell,

--- a/resources/dist/css/resized-column.css
+++ b/resources/dist/css/resized-column.css
@@ -159,6 +159,18 @@ thead th.fi-ta-header-cell.resized-column-is-resizing {
     z-index: 21;
 }
 
+/*
+ * That stacking context also traps toolbar *modals*. A column manager or filter
+ * trigger configured with ->modal()/->slideOver() renders its overlay inside
+ * .fi-ta-header-ctn, so the overlay's own z-index (40) resolves within this
+ * context and the whole modal still paints under the topbar (z-index 30).
+ * While such a modal is open, lift the context above Filament chrome; the
+ * overlay covers the page anyway, so nothing else needs to stay on top.
+ */
+.fi-ta-ctn .fi-ta-header-ctn:has(.fi-modal.fi-modal-open) {
+    z-index: 50;
+}
+
 /* Opaque header cells so scrolled rows cannot show through the thead.
    Prefer inherit so host themes (e.g. Primo #EAEEF2) keep their surface. */
 .sticky-table .fi-ta-table>thead>tr>th.fi-ta-header-cell,

--- a/tests/Unit/StickyHeaderStackingTest.php
+++ b/tests/Unit/StickyHeaderStackingTest.php
@@ -43,3 +43,23 @@ it('lifts the table toolbar above the sticky thead', function () {
         ->and((int) $zIndex['value'])->toBeGreaterThan(19)
         ->and((int) $zIndex['value'])->toBeLessThan(30);
 });
+
+it('lifts the toolbar above filament chrome while a toolbar modal is open', function () {
+    $css = file_get_contents(dirname(__DIR__, 2).'/resources/css/resized-column.css');
+
+    preg_match(
+        '/\.fi-ta-ctn \.fi-ta-header-ctn:has\(\.fi-modal\.fi-modal-open\)\s*\{(?<rules>[^}]*)\}/',
+        $css,
+        $matches,
+    );
+
+    expect($matches['rules'] ?? null)->not->toBeNull();
+
+    preg_match('/z-index:\s*(?<value>\d+)/', $matches['rules'], $zIndex);
+
+    // A slide-over/modal column manager renders inside the toolbar, so the
+    // toolbar's stacking context must clear the topbar (30) and the modal
+    // overlay (40) while the modal is open.
+    expect($zIndex['value'] ?? null)->not->toBeNull()
+        ->and((int) $zIndex['value'])->toBeGreaterThan(40);
+});


### PR DESCRIPTION
## Problem

A column manager (or filter) trigger configured as a modal / slide-over renders its heading *behind* the Filament topbar:

```php
->columnManagerTriggerAction(
    fn (Action $action) => $action
        ->button()
        ->slideOver()
        ->label('Column Manager'),
)
```

## Cause

This package sets `position: relative; z-index: 21` on `.fi-ta-header-ctn` so toolbar dropdowns stay above the sticky thead. That also creates a **stacking context**, and Filament renders the column manager modal as a sibling of its trigger *inside* that container:

```html
<div class="fi-ta-header-ctn">
  ...
  <div class="fi-modal-trigger"><button>Column Manager</button></div>
  <div class="fi-modal fi-modal-slide-over ... fi-ta-col-manager-modal">
```

So the overlay's own `z-index: 40` resolves inside the 21 context and the whole modal ends up below `.fi-topbar-ctn` (`z-index: 30`). The dropdown layout never hit this because the panel does not overlap the topbar.

## Fix

One rule — lift the toolbar context above the chrome only while a toolbar modal is open:

```css
.fi-ta-ctn .fi-ta-header-ctn:has(.fi-modal.fi-modal-open) {
    z-index: 50;
}
```

The overlay covers the page anyway, so nav menus keep their normal stacking the rest of the time. `resources/dist/css` rebuilt so the shipped asset matches (`BuildAssetsTest` checksum).

## Tests

New case in `tests/Unit/StickyHeaderStackingTest.php` asserting the `:has()` rule exists and clears the overlay's 40.

Run locally through a host app's Pest binary (this package's own `vendor/bin/pest` currently dies with `Call to undefined method PHPUnit\Event\Code\TestMethod::testData()`, a pre-existing Pest/PHPUnit mismatch in the local vendor dir):

```
Tests:  3 passed (12 assertions)
```